### PR TITLE
Using Reflect.apply when proxying

### DIFF
--- a/src/js/switcheroo.js
+++ b/src/js/switcheroo.js
@@ -296,7 +296,7 @@ var rewriter = function(CONFIG){
   class evProxy {
     apply(target, thisArg, args){
       EvalVillainHook(this.name, args);
-      return target.apply(thisArg, args)
+      return Reflect.apply(target, thisArg, args);
     }
   }
 


### PR DESCRIPTION
This avoids problems proxying functions with local modifications as in

```js
function f() {
  console.log('f');
}
f.apply = function () { console.log('g'); }

const p = new Proxy(
    f,
    {
      apply(target, thisArg, args) {
        return target.apply(thisArg, args);
      }
    });
// Logs g
p();

const q = new Proxy(
    f,
    {
      apply(target, thisArg, args) {
        return Reflect.apply(target, thisArg, args);
      }
    });
// Logs f
q();
```